### PR TITLE
refactor: Centralizar lógica de cadastro e criação de ID no

### DIFF
--- a/src/app/obras-de-arte/cadastro-obras/cadastro-obras.component.html
+++ b/src/app/obras-de-arte/cadastro-obras/cadastro-obras.component.html
@@ -1,9 +1,9 @@
 <h2>{{ acao() }}</h2>
 <mat-card class="obra-card">
   <mat-card-content>
-    <mat-form-field appearance="fill">
+    <mat-form-field appearance="fill" *ngIf="editando">
       <mat-label>Id</mat-label>
-      <input matInput [(ngModel)]="obraDeArte.id" name="id" required />
+      <input matInput [(ngModel)]="obraDeArte.id" name="id" disabled />
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Título</mat-label>

--- a/src/app/obras-de-arte/cadastro-obras/cadastro-obras.component.ts
+++ b/src/app/obras-de-arte/cadastro-obras/cadastro-obras.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
-import { OBRAS } from '../../shared/models/OBRAS';
 import { ObraDeArte } from '../../shared/models/ObraDeArte';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ObraDeArteService } from '../../shared/services/obra-de-arte.service';
 
 @Component({
   selector: 'app-cadastro-obras',
@@ -9,40 +9,37 @@ import { ActivatedRoute } from '@angular/router';
   styleUrl: './cadastro-obras.component.css',
 })
 export class CadastroObrasComponent {
-  obras = OBRAS;
-  obraDeArte = new ObraDeArte('0', '', '', 0, 0, '');
+  obras: ObraDeArte[] = [];
+  obraDeArte: ObraDeArte;
   editando = false;
 
-  constructor(private rotaAtual: ActivatedRoute) {
+  constructor(
+    private rotaAtual: ActivatedRoute,
+    private obraDeArteService: ObraDeArteService,
+    private roteador: Router
+  ) {
     const idArte = this.rotaAtual.snapshot.paramMap.get('id') || undefined;
-    if (idArte) {
+    if (idArte !== undefined) {
       this.editando = true;
-      this.obraDeArte = this.obras.filter(
-        (obraDeArte) => obraDeArte.id === idArte
-      )[0];
+      this.obraDeArte = this.obraDeArteService.obraPorId(idArte) as ObraDeArte;
+    } else {
+      this.obraDeArte = new ObraDeArte('', '', '', 0, 0, '');
     }
   }
 
   manterArte() {
     if (!this.editando) {
-      this.obras.push({
-        id: this.obraDeArte.id,
-        titulo: this.obraDeArte.titulo,
-        artista: this.obraDeArte.artista,
-        ano: this.obraDeArte.ano,
-        valorInicial: this.obraDeArte.valorInicial,
-        imagem: this.obraDeArte.imagem,
-      });
-      this.obraDeArte = {
-        id: '0',
-        titulo: '',
-        artista: '',
-        ano: 0,
-        valorInicial: 0,
-        imagem: '',
-      };
+      this.obraDeArteService.criarObra(
+        this.obraDeArte.titulo,
+        this.obraDeArte.artista,
+        this.obraDeArte.ano,
+        this.obraDeArte.valorInicial,
+        this.obraDeArte.imagem
+      );
     } else {
+      this.obraDeArteService.atualizarObra(this.obraDeArte);
     }
+    this.roteador.navigate(['/listagemArtes']);
   }
 
   acao() {

--- a/src/app/shared/services/obra-de-arte.service.ts
+++ b/src/app/shared/services/obra-de-arte.service.ts
@@ -16,9 +16,9 @@ export class ObraDeArteService {
     valorInicial: number,
     imagem: string
   ) {
-    const id = this.obras.length + 1;
+    const id = this.gerarId();
     const novaObra = new ObraDeArte(
-      id.toString(),
+      id,
       titulo,
       artista,
       ano,
@@ -28,15 +28,30 @@ export class ObraDeArteService {
     this.inserir(novaObra);
   }
 
+  private gerarId(): string {
+    return (this.obras.length + 1).toString();
+  }
+
+  private inserir(obra: ObraDeArte) {
+    this.obras.push(obra);
+  }
+
   listarObras() {
     return this.obras;
+  }
+
+  atualizarObra(obra: ObraDeArte) {
+    const index = this.obras.findIndex((o) => o.id === obra.id);
+    if (index !== -1) {
+      this.obras[index] = obra;
+    }
   }
 
   removerObra(obra: ObraDeArte) {
     this.obras = this.obras.filter((obraDeArte) => obraDeArte != obra);
   }
 
-  private inserir(obra: ObraDeArte) {
-    this.obras.push(obra);
+  obraPorId(id: string): ObraDeArte | undefined {
+    return this.obras.find((obra) => obra.id === id);
   }
 }


### PR DESCRIPTION
- Refatorado o serviço  para centralizar a lógica de operações de cadastro e responsabilidade pela criação de IDs.
- Atualizadas as alterações visuais no HTML para ocultar o campo de ID ao criar uma nova obra e exibi-lo, mas não editável, ao editar uma obra.
- Garantido que IDs únicos sejam mantidos durante o cadastro.